### PR TITLE
Fix unused extern crate build warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@
 //! middleware, but middleware that is protocol specific can be found in crates
 //! that implement those protocols.
 
-extern crate futures;
 extern crate tokio_service;
 extern crate tokio_timer;
 


### PR DESCRIPTION
Rust nightly shows a warning on compiling the project as the externed `future` crate is never used:
https://travis-ci.org/tokio-rs/tokio-middleware/jobs/269273879#L460